### PR TITLE
T5: parse() with pandera validation

### DIFF
--- a/src/tacit/schema.py
+++ b/src/tacit/schema.py
@@ -4,6 +4,7 @@ from typing import ClassVar, Self, get_origin, get_type_hints
 
 import ibis
 import ibis.expr.types as ir
+import pandera.ibis as pa
 
 
 class DataFrame[S: "Schema"](ir.Table):
@@ -57,6 +58,48 @@ class Schema:
     @classmethod
     def _ibis_schema(cls) -> ibis.Schema:
         return ibis.schema(cls._get_fields())
+
+    @classmethod
+    def _pandera_schema(cls) -> pa.DataFrameSchema:
+        columns = {
+            name: pa.Column(dtype)
+            for name, dtype in cls._ibis_schema().items()
+        }
+        return pa.DataFrameSchema(columns, strict=True)
+
+    @classmethod
+    def parse(cls, table: ir.Table) -> DataFrame[Self]:
+        """Full parsing: coerce types + validate with pandera + wrap as DataFrame.
+
+        Executes queries against the engine. Use at pipeline boundaries where
+        you're ingesting untrusted data.
+
+        Raises:
+            ValueError: Missing or extra columns.
+            pandera.errors.SchemaError: Data fails validation checks.
+        """
+        target = cls._ibis_schema()
+        actual = table.schema()
+
+        missing = sorted(set(target.names) - set(actual.names))
+        if missing:
+            raise ValueError(f"Missing columns: {missing}")
+
+        extra = sorted(set(actual.names) - set(target.names))
+        if extra:
+            raise ValueError(f"Extra columns: {extra}")
+
+        # Pandera's ibis backend doesn't support coercion — handle it ourselves
+        cast_map = {
+            col: target_type
+            for col, target_type in target.items()
+            if actual[col] != target_type
+        }
+        if cast_map:
+            table = table.cast(cast_map)
+
+        validated = cls._pandera_schema().validate(table)
+        return DataFrame._from_table(validated, cls)
 
     @classmethod
     def cast(cls, table: ir.Table) -> DataFrame[Self]:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,4 +1,5 @@
 import ibis
+import pandera.ibis as pa
 import pytest
 
 from tacit import DataFrame, Schema
@@ -98,3 +99,57 @@ def test_cast_checks_extra_before_types():
     })
     with pytest.raises(ValueError, match="Extra"):
         Iris.cast(table)
+
+
+# --- parse() tests ---
+
+
+def test_parse_returns_dataframe():
+    df = Iris.parse(_iris_table())
+    assert isinstance(df, DataFrame)
+
+
+def test_parse_preserves_data():
+    df = Iris.parse(_iris_table())
+    result = df.execute()
+    assert len(result) == 2
+    assert list(result["sepal_length"]) == [5.1, 4.9]
+
+
+def test_parse_sets_tacit_schema():
+    df = Iris.parse(_iris_table())
+    assert df._tacit_schema is Iris
+
+
+def test_parse_coerces_compatible_types():
+    """parse() handles int64 → float64 coercion (cast() would reject this)."""
+    table = ibis.memtable({"sepal_length": [5, 4], "species": ["setosa", "setosa"]})
+    df = Iris.parse(table)
+    result = df.execute()
+    assert list(result["sepal_length"]) == [5.0, 4.0]
+
+
+def test_parse_rejects_missing_columns():
+    table = ibis.memtable({"species": ["setosa"]})
+    with pytest.raises(ValueError, match="sepal_length"):
+        Iris.parse(table)
+
+
+def test_parse_rejects_extra_columns():
+    table = ibis.memtable({
+        "sepal_length": [5.1],
+        "species": ["setosa"],
+        "EXTRA": [999],
+    })
+    with pytest.raises(ValueError, match="EXTRA"):
+        Iris.parse(table)
+
+
+def test_pandera_schema_has_strict_mode():
+    schema = Iris._pandera_schema()
+    assert schema.strict is True
+
+
+def test_pandera_schema_has_expected_columns():
+    schema = Iris._pandera_schema()
+    assert set(schema.columns.keys()) == {"sepal_length", "species"}


### PR DESCRIPTION
## Summary
- Add `Schema._pandera_schema()` — generates `pandera.DataFrameSchema` from fields with `strict=True`
- Add `Schema.parse(table)` — coerces column types via `ibis.Table.cast()`, validates with pandera, returns `DataFrame[S]`
- Pre-checks missing/extra columns for clear error messages before executing
- 8 new tests covering happy path, type coercion, error cases, and pandera schema correctness

Closes #10

## Test plan
- [x] `parse()` returns `DataFrame` with correct schema and data
- [x] `parse()` coerces compatible types (e.g., `int64` → `float64`)
- [x] `parse()` rejects missing and extra columns with named errors
- [x] `_pandera_schema()` generates strict schema with expected columns
- [x] All 38 existing tests still pass