### PR TITLE
T7: @tacit.contract decorator

### DIFF
--- a/src/tacit/__init__.py
+++ b/src/tacit/__init__.py
@@ -1,3 +1,4 @@
+from .contract import contract
 from .schema import DataFrame, Schema
 
-__all__ = ["DataFrame", "Schema"]
+__all__ = ["DataFrame", "Schema", "contract"]

--- a/src/tacit/contract.py
+++ b/src/tacit/contract.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import functools
+from typing import Any, get_type_hints
+
+import ibis.expr.types as ir
+
+from .schema import DataFrame, Schema
+
+
+def _get_schema_type(annotation: Any) -> type[Schema] | None:
+    """Extract the Schema type S from a DataFrame[S] annotation, or None."""
+    origin = getattr(annotation, "__origin__", None)
+    if origin is not DataFrame:
+        return None
+    args = getattr(annotation, "__args__", None)
+    if not args:
+        return None
+    schema_type = args[0]
+    if isinstance(schema_type, type) and issubclass(schema_type, Schema):
+        return schema_type
+    return None
+
+
+def _enforce(
+    value: Any,
+    schema_type: type[Schema],
+    *,
+    validate: bool,
+    label: str,
+) -> DataFrame:
+    """Apply contract enforcement to a single value.
+
+    Args:
+        value: The value to enforce.
+        schema_type: The Schema subclass to enforce against.
+        validate: If True, use parse() (full validation). Otherwise, use cast().
+        label: Human-readable label for error messages (e.g. "parameter 'df'",
+               "return value").
+
+    Raises:
+        TypeError: If value is not an ibis Table expression.
+        ValueError/TypeError: Re-raised from cast()/parse() with context about
+            which parameter and schema failed.
+    """
+    if not isinstance(value, ir.Table):
+        raise TypeError(
+            f"Contract violation on {label}: "
+            f"expected an ibis Table for {schema_type.__name__}, "
+            f"got {type(value).__name__}"
+        )
+    try:
+        if validate:
+            return schema_type.parse(value)
+        return schema_type.cast(value)
+    except (TypeError, ValueError) as exc:
+        raise type(exc)(
+            f"Contract violation on {label} "
+            f"[{schema_type.__name__}]: {exc}"
+        ) from exc
+
+
+def contract(fn=None, /, *, validate: bool = False):
+    """Decorator that enforces DataFrame schema contracts at function boundaries.
+
+    Inspects type annotations to find DataFrame[S] parameters and return type.
+    Calls Schema.cast() on inputs and outputs by default (structural checks only,
+    zero execution cost). With validate=True, calls Schema.parse() instead (full
+    pandera validation, executes queries).
+
+    Non-DataFrame parameters and return values are passed through unchanged.
+
+    Usage:
+        @tacit.contract
+        def transform(df: DataFrame[Iris]) -> DataFrame[IrisFeatures]: ...
+
+        @tacit.contract(validate=True)
+        def ingest(df: DataFrame[Iris]) -> DataFrame[IrisFeatures]: ...
+    """
+    if fn is not None:
+        return _wrap(fn, validate=validate)
+    return lambda f: _wrap(f, validate=validate)
+
+
+def _wrap(fn, *, validate: bool):
+    hints = get_type_hints(fn)
+    return_hint = hints.pop("return", None)
+
+    param_schemas: dict[str, type[Schema]] = {}
+    for name, hint in hints.items():
+        schema = _get_schema_type(hint)
+        if schema is not None:
+            param_schemas[name] = schema
+
+    return_schema = _get_schema_type(return_hint) if return_hint else None
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        import inspect
+
+        sig = inspect.signature(fn)
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+
+        for param_name, schema_type in param_schemas.items():
+            if param_name in bound.arguments:
+                bound.arguments[param_name] = _enforce(
+                    bound.arguments[param_name],
+                    schema_type,
+                    validate=validate,
+                    label=f"parameter '{param_name}'",
+                )
+
+        result = fn(*bound.args, **bound.kwargs)
+
+        if return_schema is not None:
+            result = _enforce(
+                result,
+                return_schema,
+                validate=validate,
+                label="return value",
+            )
+
+        return result
+
+    return wrapper

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,201 @@
+import ibis
+import pytest
+
+import tacit
+from tacit import DataFrame, Schema, contract
+
+
+class Iris(Schema):
+    sepal_length: float
+    species: str
+
+
+class IrisFeatures(Iris):
+    sepal_ratio: float
+
+
+def _iris_table() -> ibis.Table:
+    return ibis.memtable({"sepal_length": [5.1, 4.9], "species": ["setosa", "setosa"]})
+
+
+def _iris_features_table() -> ibis.Table:
+    return ibis.memtable({
+        "sepal_length": [5.1, 4.9],
+        "species": ["setosa", "setosa"],
+        "sepal_ratio": [1.0, 1.0],
+    })
+
+
+# --- Default behavior (cast) ---
+
+
+def test_contract_casts_input():
+    @contract
+    def fn(df: DataFrame[Iris]) -> DataFrame[Iris]:
+        assert isinstance(df, DataFrame)
+        assert df._tacit_schema is Iris
+        return df
+
+    fn(_iris_table())
+
+
+def test_contract_casts_output():
+    @contract
+    def fn(df: DataFrame[Iris]) -> DataFrame[Iris]:
+        return df
+
+    result = fn(_iris_table())
+    assert isinstance(result, DataFrame)
+    assert result._tacit_schema is Iris
+
+
+def test_contract_casts_input_and_output_schemas():
+    @contract
+    def transform(df: DataFrame[Iris]) -> DataFrame[IrisFeatures]:
+        return df.mutate(sepal_ratio=df.sepal_length / 1.0)
+
+    result = transform(_iris_table())
+    assert isinstance(result, DataFrame)
+    assert result._tacit_schema is IrisFeatures
+
+
+def test_contract_does_not_execute_query():
+    """Default cast mode only inspects metadata — works on unexecutable expressions."""
+    table = ibis.table({"sepal_length": "float64", "species": "string"}, name="nonexistent")
+
+    @contract
+    def fn(df: DataFrame[Iris]) -> DataFrame[Iris]:
+        return df
+
+    result = fn(table)
+    assert isinstance(result, DataFrame)
+
+
+# --- validate=True (parse) ---
+
+
+def test_contract_validate_parses_input():
+    @contract(validate=True)
+    def fn(df: DataFrame[Iris]) -> DataFrame[Iris]:
+        assert isinstance(df, DataFrame)
+        assert df._tacit_schema is Iris
+        return df
+
+    fn(_iris_table())
+
+
+def test_contract_validate_coerces_types():
+    """parse() coerces int64 → float64; cast() would reject this."""
+    table = ibis.memtable({"sepal_length": [5, 4], "species": ["setosa", "setosa"]})
+
+    @contract(validate=True)
+    def fn(df: DataFrame[Iris]) -> DataFrame[Iris]:
+        return df
+
+    result = fn(table)
+    data = result.execute()
+    assert list(data["sepal_length"]) == [5.0, 4.0]
+
+
+# --- Mixed params ---
+
+
+def test_contract_passes_through_non_dataframe_params():
+    @contract
+    def fn(df: DataFrame[Iris], multiplier: float) -> DataFrame[IrisFeatures]:
+        return df.mutate(sepal_ratio=df.sepal_length * multiplier)
+
+    result = fn(_iris_table(), multiplier=2.0)
+    assert isinstance(result, DataFrame)
+    data = result.execute()
+    assert list(data["sepal_ratio"]) == [10.2, 9.8]
+
+
+def test_contract_passes_through_non_dataframe_return():
+    @contract
+    def fn(df: DataFrame[Iris]) -> int:
+        return 42
+
+    assert fn(_iris_table()) == 42
+
+
+def test_contract_with_no_annotations():
+    @contract
+    def fn(x, y):
+        return x + y
+
+    assert fn(1, 2) == 3
+
+
+def test_contract_with_kwargs():
+    @contract
+    def fn(df: DataFrame[Iris], *, verbose: bool = False) -> DataFrame[Iris]:
+        return df
+
+    result = fn(_iris_table(), verbose=True)
+    assert isinstance(result, DataFrame)
+
+
+# --- Error cases ---
+
+
+def test_contract_input_missing_columns():
+    @contract
+    def fn(df: DataFrame[Iris]) -> DataFrame[Iris]:
+        return df
+
+    table = ibis.memtable({"species": ["setosa"]})
+    with pytest.raises(ValueError, match=r"parameter 'df'.*Iris"):
+        fn(table)
+
+
+def test_contract_input_extra_columns():
+    @contract
+    def fn(df: DataFrame[Iris]) -> DataFrame[Iris]:
+        return df
+
+    table = ibis.memtable({
+        "sepal_length": [5.1],
+        "species": ["setosa"],
+        "EXTRA": [1],
+    })
+    with pytest.raises(ValueError, match=r"parameter 'df'.*Iris"):
+        fn(table)
+
+
+def test_contract_input_wrong_type():
+    @contract
+    def fn(df: DataFrame[Iris]) -> DataFrame[Iris]:
+        return df
+
+    table = ibis.memtable({"sepal_length": ["bad"], "species": ["setosa"]})
+    with pytest.raises(TypeError, match=r"parameter 'df'.*Iris"):
+        fn(table)
+
+
+def test_contract_output_schema_mismatch():
+    @contract
+    def fn(df: DataFrame[Iris]) -> DataFrame[IrisFeatures]:
+        return df
+
+    with pytest.raises((ValueError, TypeError), match=r"return value.*IrisFeatures"):
+        fn(_iris_table())
+
+
+def test_contract_input_not_a_table():
+    @contract
+    def fn(df: DataFrame[Iris]) -> DataFrame[Iris]:
+        return df
+
+    with pytest.raises(TypeError, match=r"parameter 'df'.*Iris.*got str"):
+        fn("not a table")
+
+
+def test_contract_preserves_function_metadata():
+    @contract
+    def my_transform(df: DataFrame[Iris]) -> DataFrame[Iris]:
+        """My docstring."""
+        return df
+
+    assert my_transform.__name__ == "my_transform"
+    assert my_transform.__doc__ == "My docstring."


### PR DESCRIPTION
## Summary

- Add `@tacit.contract` decorator that enforces `DataFrame[S]` schema contracts at function boundaries by inspecting type annotations via `get_type_hints()`
- Default mode uses `Schema.cast()` (structural check, zero execution cost); `validate=True` uses `Schema.parse()` (full pandera validation)
- Non-DataFrame parameters and return values pass through unchanged
- Errors name the failing parameter and schema (e.g. `"Contract violation on parameter 'df' [Iris]: Missing columns..."`)

Closes #12

## Test plan

- [x] 16 new tests in `tests/test_contract.py` covering default cast, validate=True, mixed params, error cases, and metadata preservation
- [x] Full test suite passes (55 tests)