### PR TITLE
T9: Constraint syntax spike

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -194,6 +194,54 @@ Rationale: structural checks catch the vast majority of pipeline bugs (wrong col
 type mismatches) without forcing query execution. Full validation is for boundary
 functions where you don't trust the data source.
 
+### Constraints use Annotated metadata with pandera Checks
+
+Column-level constraints use `typing.Annotated` with pandera `Check` objects
+directly. tacit re-exports `pandera.ibis.Check` as `tacit.Check` — no custom
+wrapper types.
+
+```python
+from typing import Annotated
+from tacit import Schema, Check, Nullable
+
+class Order(Schema):
+    amount: Annotated[float, Check.ge(0)]
+    status: Annotated[str, Check.isin(["pending", "shipped"])]
+    notes: Annotated[str, Nullable(True)]
+    name: str                                     # no constraints, just type
+```
+
+Why Annotated over Field() or custom types:
+
+- **No translation layer.** `Check.ge(0)` IS a pandera Check — it goes straight
+  into `pa.Column(dtype, checks=[...])`.
+- **Type and constraints in one annotation.** `get_type_hints(cls, include_extras=True)`
+  returns both the base type and constraint metadata.
+- **Composability.** Multiple constraints are additional Annotated args.
+- **No default-value ambiguity.** Unlike `Field()`, constraints are type metadata.
+- **Backward compatible.** Plain `amount: float` works unchanged.
+
+Field() can be added later without breaking Annotated users. Custom type aliases
+are already possible: `PositiveFloat = Annotated[float, Check.ge(0)]`.
+
+See [constraint_syntax.md](research/constraint_syntax.md) for the full analysis.
+
+### Non-nullable by default
+
+Columns are non-nullable by default (`nullable=False` in pandera). Users opt into
+nullability with `Nullable(True)` in Annotated metadata.
+
+Rationale: surprise nulls in production data are a top source of pipeline bugs.
+This matches the strict-by-default philosophy. `Nullable(False)` is redundant
+but allowed for explicitness.
+
+### Constraint errors propagate from pandera
+
+`parse()` lets pandera's `SchemaError` propagate directly for constraint
+violations. No wrapping. pandera already provides clear error messages naming
+the column, check, and failure cases. A `tacit.ValidationError` wrapper can be
+added later as a non-breaking subclass if needed.
+
 
 ## Open Questions
 
@@ -259,29 +307,7 @@ def engineer_features(df: tacit.DataFrame[Iris]) -> tacit.DataFrame[IrisFeatures
 Without either, the type checker flags the error: `ibis.Table` is not
 assignable to `tacit.DataFrame[IrisFeatures]`. You cannot forget.
 
-### Constraint syntax
-
-How do users express "non-negative float" or "string matching regex X"?
-Options:
-
-```python
-# Option A: Annotated metadata (like annotated-types / Pydantic)
-class Order(tacit.Schema):
-    amount: Annotated[float, tacit.Ge(0)]
-    status: Annotated[str, tacit.OneOf("pending", "shipped", "delivered")]
-
-# Option B: Field() calls (like Pydantic / pandera)
-class Order(tacit.Schema):
-    amount: float = tacit.Field(ge=0)
-    status: str = tacit.Field(isin=["pending", "shipped", "delivered"])
-
-# Option C: Custom types (like NewType)
-NonNegativeFloat = tacit.Constrained(float, ge=0)
-class Order(tacit.Schema):
-    amount: NonNegativeFloat
-```
-
-These are not mutually exclusive. Needs exploration.
+### Constraint syntax *(resolved — see Decisions)*
 
 ### Lazy validation with ibis
 
@@ -332,6 +358,27 @@ with full type safety. Python lacks the type-level computation needed for this
    (dynamic schema classes) without static checking. Pragmatic stopgap.
 
 This is the v2 differentiator. v0 is concrete schemas at pipeline boundaries.
+
+### Column[T] descriptors for expression building
+
+A SQLAlchemy-style `Column[T]` annotation would make schema fields usable as ibis
+deferred expressions:
+
+```python
+class Order(Schema):
+    amount: Column[float] = Column(Check.ge(0))
+
+t.filter(Order.amount > 0)       # Order.amount → ibis._.amount (Deferred)
+t.mutate(doubled=Order.amount * 2)
+```
+
+pyright correctly resolves the descriptor protocol — `Order.amount` is typed as
+`Deferred`, not `float`. The pattern is proven at scale by SQLAlchemy's `Mapped[T]`.
+
+**Trade-off**: every constrained field must be annotated `Column[float]` instead of
+`float`. v0 ships with Annotated to see if the ergonomics are acceptable. If typed
+column references are needed, the `Column[T]` upgrade is well-understood and
+non-breaking. See [constraint_syntax.md](research/constraint_syntax.md) for details.
 
 ### Other future work
 

--- a/docs/research/SUMMARY.md
+++ b/docs/research/SUMMARY.md
@@ -178,3 +178,4 @@ today with no changes.
 | [pandera_programmatic.py](pandera_programmatic.py) | Programmatic schema construction |
 | [e2e_proof_of_concept.py](e2e_proof_of_concept.py) | Full end-to-end proof of concept (runtime) |
 | [type_check_test.py](type_check_test.py) | Static type checking proof (pyright) |
+| [constraint_syntax.md](constraint_syntax.md) | Constraint syntax spike: Annotated + pandera Check decision |

--- a/docs/research/constraint_syntax.md
+++ b/docs/research/constraint_syntax.md
@@ -1,0 +1,241 @@
+# Constraint Syntax Spike
+
+**Date**: 2026-04-04
+**Verdict**: `Annotated` metadata with `pandera.Check` objects. No custom wrappers.
+
+---
+
+## The question
+
+How should users express column-level constraints (non-negative, one-of, etc.)
+in tacit schema definitions?
+
+## Options evaluated
+
+### Option A: Annotated metadata
+
+```python
+from typing import Annotated
+from tacit import Schema, Check, Nullable
+
+class Order(Schema):
+    amount: Annotated[float, Check.ge(0)]
+    status: Annotated[str, Check.isin(["pending", "shipped"])]
+    notes: Annotated[str, Nullable(True)]
+```
+
+### Option B: Field() calls
+
+```python
+class Order(Schema):
+    amount: float = tacit.Field(ge=0)
+    status: str = tacit.Field(isin=["pending", "shipped"])
+```
+
+### Option C: Custom types
+
+```python
+NonNegativeFloat = tacit.Constrained(float, ge=0)
+class Order(Schema):
+    amount: NonNegativeFloat
+```
+
+## Decision: Option A (Annotated)
+
+### Why Annotated wins
+
+1. **No translation layer.** tacit delegates constraint validation to pandera.
+   `Check.ge(0)` IS a pandera Check — it goes straight into
+   `pa.Column(dtype, checks=[...])` with zero conversion. Defining `tacit.Ge(0)`
+   objects that wrap pandera Checks adds code for no benefit.
+
+2. **Type and constraints in one annotation.** `get_type_hints(cls, include_extras=True)`
+   returns both the base type and constraint metadata in a single pass. No need to
+   separately inspect class `__dict__` for Field() defaults.
+
+3. **Composability.** Multiple constraints are additional Annotated args:
+   `Annotated[float, Check.ge(0), Check.le(100)]`. No special syntax for combining.
+
+4. **No default-value ambiguity.** `amount: float = Field(ge=0)` looks like a default
+   value assignment. Annotated makes it clear these are type metadata.
+
+5. **Modern Python direction.** PEP 593 Annotated is where the ecosystem is headed.
+   Pydantic v2 recommends it. tacit has no legacy to support Field().
+
+6. **Backward compatible.** Plain `amount: float` works unchanged — Annotated is
+   opt-in per field.
+
+### Why not Field()
+
+- Requires inspecting `cls.__dict__` separately from type hints — two code paths.
+- Default-value semantics are confusing.
+- Pydantic supports both for legacy reasons; tacit doesn't have that constraint.
+- Can be added later without breaking Annotated users.
+
+### Why not custom types
+
+- Combinatorial explosion: need a type for every constraint combination.
+- Users can already create reusable aliases:
+  `PositiveFloat = Annotated[float, Check.ge(0)]` — no library support needed.
+
+## Reuse pandera directly
+
+tacit re-exports `pandera.ibis.Check` as `tacit.Check` — literally `Check = pa.Check`.
+No subclass, no wrapper. Users get the full pandera Check API. If pandera adds new
+checks, they're available in tacit immediately.
+
+The only tacit-defined constraint type is `Nullable(bool)`.
+
+### Public API for constraints
+
+```python
+from typing import Annotated
+from tacit import Schema, DataFrame, Check, Nullable
+```
+
+- `Check` — re-export of `pandera.ibis.Check`
+- `Nullable(True/False)` — tacit marker for column nullability
+
+### Why not wrap pandera Checks
+
+- Wrapping adds a translation layer for a hypothetical future backend swap.
+- pandera IS the validation engine for the foreseeable future.
+- tacit's philosophy: "opinionated glue, not a reimplementation."
+- If we ever need to swap, we can introduce wrappers as a non-breaking addition.
+
+## Nullable: strict by default
+
+Columns are non-nullable by default. This matches tacit's strict-by-default
+philosophy — surprise nulls in production data are a top source of pipeline bugs.
+
+```python
+class Order(Schema):
+    name: str                                     # nullable=False (default)
+    amount: Annotated[float, Check.ge(0)]         # nullable=False (default)
+    nickname: Annotated[str, Nullable(True)]      # nullable=True (opt-in)
+```
+
+Implementation: `_pandera_schema()` passes `nullable=False` to every `pa.Column`
+unless a `Nullable(True)` marker is found in the field's Annotated metadata.
+
+`Nullable(False)` is redundant but allowed for explicitness.
+
+## Error handling
+
+pandera's `SchemaError` propagates directly from `parse()`. No wrapping.
+
+pandera already provides clear error messages:
+
+```
+Column 'amount' failed element-wise validator number 0:
+greater_than_or_equal_to(0) failure cases: {'amount': -5.0}
+```
+
+A `tacit.ValidationError` wrapper can be added later if needed, without breaking
+existing `except SchemaError` handlers (by subclassing).
+
+## Inheritance
+
+Constraints compose through schema inheritance via `get_type_hints()` MRO
+resolution. No special handling needed.
+
+```python
+class Base(Schema):
+    amount: Annotated[float, Check.ge(0)]
+
+class Child(Base):
+    name: str
+# Child inherits amount with Check.ge(0)
+
+class Stricter(Base):
+    amount: Annotated[float, Check.ge(0), Check.le(100)]
+# Stricter overrides amount with tighter constraints
+```
+
+Verified: `get_type_hints(Child, include_extras=True)` returns the parent's
+Annotated metadata for inherited fields.
+
+## Implementation sketch
+
+### New: `src/tacit/constraints.py`
+
+```python
+from dataclasses import dataclass
+import pandera.ibis as pa
+
+Check = pa.Check
+
+@dataclass(frozen=True)
+class Nullable:
+    allow: bool = True
+```
+
+### Modified: `src/tacit/schema.py`
+
+`__init_subclass__` changes from `get_type_hints(cls)` to
+`get_type_hints(cls, include_extras=True)`. For each hint:
+
+1. If `Annotated[T, ...]`: extract base type `T` into `_fields`, extract `Check`
+   and `Nullable` instances into `_field_checks` and `_field_nullable`.
+2. If plain type: store in `_fields` as before, no checks, `nullable=False`.
+
+`_pandera_schema()` uses the extracted checks:
+
+```python
+@classmethod
+def _pandera_schema(cls) -> pa.DataFrameSchema:
+    columns = {}
+    for name, dtype in cls._ibis_schema().items():
+        checks = cls._field_checks.get(name, [])
+        nullable = cls._field_nullable.get(name, False)
+        columns[name] = pa.Column(dtype, checks=checks, nullable=nullable)
+    return pa.DataFrameSchema(columns, strict=True)
+```
+
+No changes to `_ibis_schema()`, `cast()`, `DataFrame`, or `contract.py`.
+
+### Modified: `src/tacit/__init__.py`
+
+```python
+from .constraints import Check, Nullable
+# added to __all__
+```
+
+## Future exploration: Column[T] descriptors
+
+A SQLAlchemy-style `Column[T]` annotation could make schema fields usable as ibis
+deferred expressions:
+
+```python
+class Order(Schema):
+    amount: Column[float] = Column(Check.ge(0))
+
+# Then Order.amount returns ibis._.amount (a Deferred)
+t.filter(Order.amount > 0)      # works in any ibis expression
+t.mutate(doubled=Order.amount * 2)
+```
+
+This requires the annotation itself to be the descriptor type (`Column[float]`
+instead of `float`). pyright correctly resolves the descriptor protocol and infers
+`Deferred` for class-level access. The pattern is proven at scale by SQLAlchemy's
+`Mapped[T]`.
+
+**Trade-off**: every constrained field must be annotated `Column[float]` instead
+of `float` — more verbose, but the only way to get typed deferred column references.
+
+**Decision**: deferred. Ship v0 with Annotated to see if the ergonomics are
+acceptable. If users want typed column references for expression building, the
+`Column[T]` upgrade path is well-understood and non-breaking.
+
+### Verified findings
+
+| Question | Answer |
+|----------|--------|
+| `get_type_hints(cls, include_extras=True)` preserves Annotated? | Yes |
+| `get_args()` extracts base type + Check metadata? | Yes |
+| Multiple Checks compose in Annotated? | Yes — separate args |
+| pandera Check objects work directly in `pa.Column(checks=[...])`? | Yes |
+| Inheritance preserves Annotated metadata? | Yes — via MRO |
+| pandera `nullable=False` catches nulls with ibis? | Yes |
+| `Column() -> Any` trick (Pydantic-style) passes pyright? | Yes, but descriptor invisible |
+| `Column[T]` with `__get__` overload → pyright sees Deferred? | Yes |


### PR DESCRIPTION
## Summary
- Decides constraint syntax for tacit v0: `Annotated` metadata with `pandera.Check` objects directly
- Evaluates three options (Annotated, Field(), custom types) with rationale for choosing Annotated
- Documents non-nullable-by-default and pandera error propagation decisions
- Explores SQLAlchemy-style `Column[T]` descriptors, deferred to future version
- Updates DESIGN.md open questions → decided, adds future work entry for Column[T]

Closes #14

## Deliverables
- `docs/research/constraint_syntax.md` — full analysis with implementation sketch
- `docs/DESIGN.md` — constraint syntax resolved, nullable-by-default, Column[T] future work
- `docs/research/SUMMARY.md` — research artifact index updated

## Test plan
- [ ] Review research document for completeness and accuracy
- [ ] Verify DESIGN.md open question is resolved and decisions section is coherent
- [ ] Confirm implementation sketch in research doc aligns with current `schema.py`