### PR TITLE
Add tacit validation error API

### DIFF
--- a/dev/research/validation_error_backend_matrix.py
+++ b/dev/research/validation_error_backend_matrix.py
@@ -1,0 +1,86 @@
+"""Ad hoc comparison of tacit validation errors across ibis backends.
+
+Examples:
+
+    UV_CACHE_DIR=/tmp/uv-cache uv run python dev/research/validation_error_backend_matrix.py duckdb
+    UV_CACHE_DIR=/tmp/uv-cache uv run --with 'ibis-framework[polars]>=12.0.0' --with 'polars>=1.0.0' python dev/research/validation_error_backend_matrix.py polars
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Annotated
+
+import ibis
+
+from tacit import Check, Schema
+from tacit.errors import ValidationError
+
+
+class Order(Schema):
+    amount: Annotated[float, Check.ge(0)]
+    status: str
+
+
+def _connect(name: str):
+    if name == "duckdb":
+        return ibis.duckdb.connect()
+    if name == "polars":
+        return ibis.polars.connect()
+    raise ValueError(f"unsupported backend: {name}")
+
+
+def _table(con):
+    data = {
+        "amount": ["bad", "-1", "10"],
+        "status": ["pending", None, "pending"],
+    }
+    if con.name == "polars":
+        import polars as pl
+
+        data = pl.DataFrame(data)
+    return con.create_table(
+        "orders_tmp",
+        data,
+        overwrite=True,
+    )
+
+
+def _print_exception(exc: BaseException) -> None:
+    print("type:", type(exc).__name__)
+    print("message:", str(exc))
+    if isinstance(exc, ValidationError):
+        print("phase:", exc.phase)
+        print("schema:", exc.schema.__name__)
+        print("column:", exc.column)
+        print("reason_code:", exc.reason_code)
+        print("boundary_label:", exc.boundary_label)
+        print(
+            "original:",
+            type(exc.original).__name__ if exc.original is not None else None,
+        )
+        print(
+            "cause:",
+            type(exc.__cause__).__name__ if exc.__cause__ is not None else None,
+        )
+
+
+def main() -> int:
+    backend = sys.argv[1] if len(sys.argv) > 1 else "duckdb"
+    print("backend:", backend)
+    con = _connect(backend)
+    table = _table(con)
+    print("input schema:", table.schema())
+
+    try:
+        Order.parse(table)
+    except Exception as exc:  # noqa: BLE001 - ad hoc research script
+        _print_exception(exc)
+        return 0
+
+    print("parse unexpectedly succeeded")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev/research/validation_error_handling.md
+++ b/dev/research/validation_error_handling.md
@@ -1,0 +1,560 @@
+# Validation Error Handling Spike
+
+**Date**: 2026-04-07
+**Issue**: #35
+**Verdict**: Prefer a small tacit exception hierarchy rooted in a common
+`TacitValidationError`, while preserving the original pandera/backend exception
+as the cause instead of trying to normalize every engine-specific detail.
+
+---
+
+## The question
+
+How should tacit expose validation failures so that users can reliably identify
+and handle them, without re-implementing the full error surface of pandera,
+ibis, and every backend engine?
+
+This question matters because tacit's primary value proposition is *clear,
+useful failures at data boundaries*. Today, the error surface is split:
+
+- structural checks in tacit raise `ValueError` / `TypeError`
+- constraint and schema failures from pandera raise `SchemaError`
+- coercion failures from `ibis.Table.cast()` raise backend-specific exceptions
+  like DuckDB's `ConversionException`
+- `@contract(validate=True)` currently lets those raw exceptions through without
+  adding parameter/return-value context
+
+The result is informative in some cases, but not stable enough to serve as an
+API for users who want to catch and handle validation errors.
+
+## Goals
+
+1. Give users a reliable way to identify the *kind* of failure.
+2. Preserve boundary context: which tacit operation failed, against which
+   schema, and for which contract parameter/return value.
+3. Preserve the useful low-level details from pandera/backend exceptions.
+4. Keep the design small enough that tacit does not become an error-normalizing
+   framework for every ibis backend.
+
+## Non-goals
+
+1. Re-implement every pandera or backend exception class.
+2. Promise a portable, engine-agnostic error message string.
+3. Normalize all failure-case payloads into one schema.
+4. Hide backend details that are useful for debugging real pipelines.
+
+## Important project context
+
+Backward compatibility is **not** a meaningful constraint for this decision.
+Tacit is still pre-stable and does not have an established user base that would
+justify carrying forward a weaker API just to avoid breakage.
+
+That means the design should optimize for the best long-term public exception
+API, not for preserving today's ad hoc mix of `ValueError`, `TypeError`,
+`SchemaError`, and backend exceptions.
+
+## Current tacit behavior
+
+### High-level failure matrix
+
+| Scenario | Where it fails today | What the user sees |
+|---|---|---|
+| Missing/extra columns in `cast()` / `parse()` | tacit `_check_columns()` | `ValueError` |
+| Wrong dtype in `cast()` | tacit `cast()` | `TypeError` |
+| Coercion failure in `parse()` | `ibis.Table.cast()` / backend execution | backend-specific exception |
+| Constraint/nullability/check failure in `parse()` | pandera ibis backend | `pandera.errors.SchemaError` |
+| Multiple pandera failures with `lazy=True` | pandera ibis backend | `pandera.errors.SchemaErrors` |
+| Custom pandera check crashes | pandera wraps it | `pandera.errors.SchemaError` with `reason_code=CHECK_ERROR` |
+| `@contract(validate=True)` failure | raw exception bubbles through | no contract-specific context |
+
+### Why this split exists
+
+Tacit performs **structural** checks itself, but it performs **coercion** via
+`ibis.Table.cast()` before handing off **data validation** to pandera:
+
+```python
+target = cls._ibis_schema()
+actual = table.schema()
+cls._check_columns(target, actual)
+
+cast_map = {col: target_type for col, target_type in target.items() if actual[col] != target_type}
+if cast_map:
+    table = table.cast(cast_map)
+
+validated = cls._pandera_schema().validate(table)
+```
+
+Source: [src/tacit/schema.py](../../src/tacit/schema.py)
+
+That means:
+
+- missing/extra columns are controlled by tacit
+- successful casts disappear
+- failed casts are backend execution failures, not pandera failures
+- pandera only sees the post-cast table
+
+This is the single most important fact shaping the design.
+
+## Evidence
+
+### 1. Pandera's Ibis backend already has structured validation errors
+
+Pandera documents that Ibis validation raises `SchemaError` eagerly and
+`SchemaErrors` with `lazy=True`:
+
+- Pandera Ibis guide:
+  <https://pandera.readthedocs.io/en/stable/ibis.html>
+- Pandera lazy validation guide:
+  <https://pandera.readthedocs.io/en/stable/lazy_validation.html>
+- Pandera error classes:
+  <https://pandera.readthedocs.io/en/stable/reference/generated/pandera.errors.SchemaError.html>
+  and
+  <https://pandera.readthedocs.io/en/stable/reference/generated/pandera.errors.SchemaErrors.html>
+
+Pandera's `SchemaError` is not just a message; it carries structured fields:
+
+- `reason_code`
+- `failure_cases`
+- `check`
+- `check_output`
+- `column_name`
+- `schema`
+
+Local source:
+
+- `.venv/lib/python3.12/site-packages/pandera/errors.py`
+- `.venv/lib/python3.12/site-packages/pandera/backends/ibis/container.py`
+- `.venv/lib/python3.12/site-packages/pandera/backends/ibis/components.py`
+
+Important nuance: for the Ibis backend, `column_name` is often `None`, even
+when the error message clearly identifies a column. The useful structured
+fields are `reason_code`, `check`, and `failure_cases`.
+
+### 2. Coercion failures do *not* come from pandera in tacit's flow
+
+Pandera's Ibis docs say parsers apply `coerce=True` as part of validation, but
+in the installed `pandera 0.30.1` Ibis backend, `coerce=True` did not coerce in
+practice in local testing:
+
+```python
+schema = pa.DataFrameSchema({"a": pa.Column(float, coerce=True)})
+schema.validate(ibis.memtable({"a": [1, 2]}))
+# SchemaError: expected column 'a' to have type float64, got int64
+```
+
+Tacit therefore correctly performs coercion itself today. But once tacit calls
+`table.cast(...)`, any failure is whatever the backend chooses to raise. With
+DuckDB, the observed type was `_duckdb.ConversionException`.
+
+This means coercion failure is *not* something tacit can reliably identify by
+matching a specific exception class across backends.
+
+### 3. Pandera's lazy mode is useful, but tacit does not currently use it
+
+Pandera's Ibis backend can aggregate multiple failures into `SchemaErrors`,
+including multiple checks on multiple columns. The aggregated object contains:
+
+- `schema_errors`: a list of `SchemaError`
+- `failure_cases`: a consolidated failure table
+- `message`: a grouped error report
+
+This is useful evidence for future API design, but tacit currently calls
+`validate(..., lazy=False)` implicitly via `schema.validate(table)`.
+
+### 4. Pandera distinguishes failure reasons more reliably than message text
+
+Observed `reason_code` values from local experiments:
+
+- `COLUMN_NOT_IN_DATAFRAME`
+- `COLUMN_NOT_IN_SCHEMA`
+- `WRONG_DATATYPE`
+- `SERIES_CONTAINS_NULLS`
+- `DATAFRAME_CHECK`
+- `CHECK_ERROR`
+
+This is a better hook for a tacit API than parsing human-readable strings.
+
+### 5. `@contract(validate=True)` is the main place where tacit must add value
+
+Users need contract context that pandera/backend exceptions do not know about:
+
+- was this a function input or output?
+- which parameter?
+- which schema was being enforced?
+
+This is tacit's unique information, and it should be added consistently even if
+the underlying error remains a pandera or backend exception.
+
+## Local experiments
+
+Script:
+[validation_error_scenarios.py](validation_error_scenarios.py)
+
+Run:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache uv run python dev/research/validation_error_scenarios.py
+```
+
+### Key observed shapes
+
+#### `tacit.parse()` coercion failure
+
+```text
+type: _duckdb.ConversionException
+message: Conversion Error: Could not convert string 'bad' to DOUBLE ...
+```
+
+Takeaway: backend-specific, rich, not something tacit should try to rewrite into
+a fake portable message.
+
+#### `tacit.parse()` constraint failure
+
+```text
+type: pandera.errors.SchemaError
+reason_code: SchemaErrorReason.DATAFRAME_CHECK
+check: <Check greater_than_or_equal_to ...>
+failure_cases: pandas.DataFrame
+```
+
+Takeaway: pandera already exposes a meaningful structured error surface.
+
+#### Pandera eager wrong dtype
+
+```text
+type: pandera.errors.SchemaError
+reason_code: SchemaErrorReason.WRONG_DATATYPE
+check: "dtype('float64')"
+failure_cases: 'string'
+```
+
+Takeaway: wrong-dtype validation inside pandera is already categorized.
+
+#### Pandera lazy aggregated errors
+
+```text
+type: pandera.errors.SchemaErrors
+schema_errors: list[SchemaError]
+```
+
+Takeaway: if tacit ever opts into `lazy=True`, there is already a structured
+aggregate shape to preserve.
+
+#### Custom check execution error
+
+```text
+type: pandera.errors.SchemaError
+reason_code: SchemaErrorReason.CHECK_ERROR
+failure_cases: 'ZeroDivisionError("division by zero")'
+```
+
+Takeaway: pandera already distinguishes "validation failed" from "check code
+itself blew up".
+
+## What users usually need to handle
+
+From a pipeline user's perspective, the handling needs are coarse:
+
+1. **Structural contract mismatch**
+   The table shape is wrong: missing columns, extra columns, wrong dtypes in
+   `cast()`.
+
+2. **Coercion failure**
+   The source data cannot be converted into the declared schema types.
+
+3. **Constraint validation failure**
+   The data has the right shape but violates declared checks/nullability.
+
+4. **Validation/check execution failure**
+   A custom check or backend operation failed for reasons other than "bad data".
+
+5. **Boundary context**
+   Did this happen in `Schema.parse()`, in a contract input, or in a contract
+   output?
+
+Users generally do **not** need tacit to normalize:
+
+- every backend exception class
+- every backend message format
+- every `failure_cases` payload into a single table shape
+
+## Candidate designs
+
+### Option A: Keep raw exceptions, only improve docs
+
+Behavior:
+
+- `cast()` keeps raising `ValueError` / `TypeError`
+- `parse()` keeps surfacing `SchemaError` and backend exceptions
+- `@contract(validate=True)` maybe prefixes the message, but no new exception API
+
+Pros:
+
+- minimal implementation
+- preserves maximum detail
+- no backward-compatibility story to manage
+
+Cons:
+
+- no stable error API
+- users must catch a grab-bag of exception types
+- contract context remains weak unless tacit rewrites messages ad hoc
+
+Verdict: too weak for tacit's value proposition.
+
+### Option B: Single tacit wrapper with coarse category metadata
+
+Behavior:
+
+- `parse()` / `cast()` / `@contract` raise a tacit exception type
+- the tacit exception carries coarse structured metadata
+- the original pandera/backend exception is preserved as `__cause__` and/or an
+  explicit `original` attribute
+
+Possible fields:
+
+```python
+class ValidationKind(Enum):
+    STRUCTURAL = "structural"
+    COERCION = "coercion"
+    CONSTRAINT = "constraint"
+    CHECK_EXECUTION = "check_execution"
+    UNKNOWN = "unknown"
+
+class ValidationPhase(Enum):
+    CAST = "cast"
+    PARSE = "parse"
+    CONTRACT_INPUT = "contract_input"
+    CONTRACT_OUTPUT = "contract_output"
+
+class TacitValidationError(Exception):
+    kind: ValidationKind
+    phase: ValidationPhase
+    schema: type[Schema]
+    boundary_label: str | None
+    reason_code: str | None
+    column: str | None
+    check: object | None
+    failure_cases: object | None
+    original: BaseException
+```
+
+Pros:
+
+- one stable catch point for users
+- preserves tacit's unique context
+- avoids re-implementing backend detail
+- works for both pandera and backend exceptions
+
+Cons:
+
+- changes public exception behavior
+- needs careful compatibility story
+- users who currently catch `SchemaError` directly would need migration help
+
+Verdict: workable, but less Pythonic than a small hierarchy if tacit is ready
+to commit to a few stable categories.
+
+### Option C: Small hierarchy of tacit exceptions
+
+Behavior:
+
+- `TacitValidationError` as the common base
+- `TacitStructuralError`
+- `TacitCoercionError`
+- `TacitConstraintError`
+- `TacitCheckExecutionError`
+
+Potentially no `Unknown` subclass at first. If tacit cannot classify a failure
+confidently, it can raise the base `TacitValidationError`.
+
+Pros:
+
+- very explicit `except` blocks
+- no need to inspect `.kind`
+- aligns with Python's built-in exception handling model
+- allows subtype-specific fields later if the API needs them
+- gives type checkers/editors a natural narrowing model
+
+Cons:
+
+- more public API surface than a single wrapper
+- requires discipline to avoid inventing too many subclasses
+- still needs a fallback strategy for ambiguous failures
+
+Verdict: best fit if tacit wants a stable public handling API now, provided the
+hierarchy stays intentionally small.
+
+### Option D: Hybrid, but contract-only wrapping
+
+Behavior:
+
+- `Schema.parse()` keeps current raw exceptions
+- `@contract(validate=True)` wraps them with contract context
+
+Pros:
+
+- minimal disruption
+- fixes the most obvious UX hole
+
+Cons:
+
+- `Schema.parse()` still lacks a stable handling API
+- users get different exception models depending on how they invoke tacit
+
+Verdict: better than today, but still fragmented.
+
+## Recommendation
+
+Recommend **Option C** with a deliberately small hierarchy:
+
+```python
+class TacitError(Exception):
+    pass
+
+
+class TacitValidationError(TacitError):
+    schema: type[Schema]
+    phase: ValidationPhase
+    boundary_label: str | None
+    original: BaseException
+    reason_code: str | None
+    check: object | None
+    failure_cases: object | None
+    column: str | None
+
+
+class TacitStructuralError(TacitValidationError):
+    pass
+
+
+class TacitCoercionError(TacitValidationError):
+    pass
+
+
+class TacitConstraintError(TacitValidationError):
+    pass
+
+
+class TacitCheckExecutionError(TacitValidationError):
+    pass
+```
+
+If tacit cannot classify a failure confidently, it should raise the base
+`TacitValidationError` rather than inventing more subclasses too early.
+
+This best matches the stated goal:
+
+- users get a stable API for identification and handling
+- users can write direct, idiomatic `except TacitCoercionError` blocks
+- tacit adds the context only tacit knows
+- pandera/backend details remain available
+- tacit avoids pretending it can normalize all engine failures
+
+### Recommended invariants
+
+1. Any validation failure originating from `Schema.cast`, `Schema.parse`, or
+   `@contract` should be catchable as `TacitValidationError`.
+2. The original exception should always be available via `__cause__` and an
+   explicit attribute like `.original`.
+3. Tacit should preserve boundary metadata (`schema`, `phase`,
+   `boundary_label`) regardless of the subclass.
+4. For pandera-backed errors, tacit should preserve `reason_code`, `check`, and
+   `failure_cases` on a best-effort basis.
+5. Tacit should only use specialized subclasses when it can classify the
+   failure confidently from its own control flow or from stable pandera reason
+   codes.
+
+### Practical mapping
+
+| Source | Recommended tacit exception |
+|---|---|
+| tacit missing/extra/wrong type in `cast()` | `TacitStructuralError` |
+| failure during tacit's own pre-validation cast step | `TacitCoercionError` |
+| `SchemaError` with `reason_code=CHECK_ERROR` | `TacitCheckExecutionError` |
+| other `SchemaError` / `SchemaErrors` from pandera validation | `TacitConstraintError` |
+| unexpected or ambiguous failure during validation | `TacitValidationError` |
+
+This is intentionally coarse. The original exception retains the full detail.
+
+### Why this is preferable to a `.kind` field
+
+The `.kind` approach is mostly equivalent in expressiveness, but a small
+hierarchy is more natural in Python:
+
+- `except TacitCoercionError` is cleaner than `except TacitValidationError as e`
+  followed by `if e.kind == ...`
+- subtype-specific fields can be added later without turning the base class into
+  a pile of optional attributes
+- editors and type checkers can narrow by exception class more naturally than by
+  runtime metadata
+
+The main argument against the hierarchy is taxonomy churn. The solution is not
+to flatten everything into `.kind`; it is to keep the hierarchy small and use
+the base class as the fallback for ambiguous cases.
+
+## Compatibility options
+
+If backward compatibility is a concern, there are two plausible rollouts:
+
+### Rollout 1: Introduce tacit exceptions everywhere
+
+- change `parse()` / `cast()` / `@contract` to raise tacit exceptions now
+- preserve original exception as cause
+- document the migration
+
+### Rollout 2: Introduce opt-in wrapping first
+
+- add `wrap_errors=True` or a config flag
+- transition docs/examples first
+- make it default later
+
+Given tacit's current stage, **Rollout 1** is the recommended path. There is no
+meaningful installed base to protect, so the project should adopt the cleaner
+exception API directly instead of introducing temporary compatibility layers.
+
+## What tacit should not try to normalize
+
+1. Backend exception classes across DuckDB, BigQuery, Snowflake, etc.
+2. The textual message format of engine exceptions.
+3. Exact `failure_cases` shapes across pandera failure modes.
+4. Every possible backend execution failure into a large inheritance tree.
+
+Those are the places where normalization becomes a fool's errand.
+
+## Suggested next implementation steps
+
+1. Define the exception classes and stable metadata fields.
+2. Decide which subclass-specific fields, if any, should exist at v1.
+3. Update `@contract(validate=True)` first so contract context is always added.
+4. Update `Schema.parse()` / `Schema.cast()` to emit the same exception family.
+5. Add tests for:
+   - contract input/output validated failures
+   - coercion failure classification
+   - constraint failure classification
+   - preservation of original exception as cause
+
+## References
+
+### Local source
+
+- [src/tacit/schema.py](../../src/tacit/schema.py)
+- [src/tacit/contract.py](../../src/tacit/contract.py)
+- [.venv/lib/python3.12/site-packages/pandera/errors.py](../../.venv/lib/python3.12/site-packages/pandera/errors.py)
+- [.venv/lib/python3.12/site-packages/pandera/backends/ibis/container.py](../../.venv/lib/python3.12/site-packages/pandera/backends/ibis/container.py)
+- [.venv/lib/python3.12/site-packages/pandera/backends/ibis/components.py](../../.venv/lib/python3.12/site-packages/pandera/backends/ibis/components.py)
+
+### Official docs
+
+- Pandera Ibis guide:
+  <https://pandera.readthedocs.io/en/stable/ibis.html>
+- Pandera lazy validation:
+  <https://pandera.readthedocs.io/en/stable/lazy_validation.html>
+- Pandera `SchemaError`:
+  <https://pandera.readthedocs.io/en/stable/reference/generated/pandera.errors.SchemaError.html>
+- Pandera `SchemaErrors`:
+  <https://pandera.readthedocs.io/en/stable/reference/generated/pandera.errors.SchemaErrors.html>
+
+### Research script
+
+- [validation_error_scenarios.py](validation_error_scenarios.py)

--- a/dev/research/validation_error_scenarios.py
+++ b/dev/research/validation_error_scenarios.py
@@ -1,0 +1,163 @@
+"""Explore validation error shapes across tacit, pandera, and ibis.
+
+Run with:
+
+    UV_CACHE_DIR=/tmp/uv-cache uv run python dev/research/validation_error_scenarios.py
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Callable
+
+import ibis
+import pandera.ibis as pa
+
+from tacit import Check, DataFrame, Schema, contract
+
+
+class Order(Schema):
+    amount: Annotated[float, Check.ge(0), Check.le(100)]
+    status: str
+
+
+def _print_exception(exc: BaseException) -> None:
+    print(f"type: {type(exc).__module__}.{type(exc).__qualname__}")
+    print(f"message: {exc}")
+
+    for attr in [
+        "reason_code",
+        "column_name",
+        "check",
+        "failure_cases",
+        "schema_errors",
+    ]:
+        if hasattr(exc, attr):
+            value = getattr(exc, attr)
+            print(f"{attr}: {type(value).__module__}.{type(value).__qualname__}")
+            print(repr(value)[:1000])
+
+    if exc.__cause__ is not None:
+        print(
+            "cause:",
+            f"{type(exc.__cause__).__module__}.{type(exc.__cause__).__qualname__}",
+        )
+        print(repr(exc.__cause__)[:1000])
+
+
+def _run(name: str, fn: Callable[[], Any]) -> None:
+    print(f"=== {name} ===")
+    try:
+        result = fn()
+        print("result:", type(result))
+    except Exception as exc:  # noqa: BLE001 - research script
+        _print_exception(exc)
+    print()
+
+
+schema = pa.DataFrameSchema(
+    {
+        "amount": pa.Column(
+            float,
+            checks=[pa.Check.ge(0), pa.Check.le(100)],
+            nullable=False,
+        ),
+        "status": pa.Column(
+            str,
+            checks=[pa.Check.isin(["pending", "shipped"])],
+            nullable=False,
+        ),
+    },
+    strict=True,
+)
+
+
+@contract(validate=True)
+def validated_identity(df: DataFrame[Order]) -> DataFrame[Order]:
+    return df
+
+
+def main() -> None:
+    _run(
+        "tacit.cast structural mismatch",
+        lambda: Order.cast(ibis.memtable({"amount": ["bad"], "status": ["pending"]})),
+    )
+
+    _run(
+        "tacit.parse coercion failure",
+        lambda: Order.parse(
+            ibis.memtable({"amount": ["bad"], "status": ["pending"]})
+        ),
+    )
+
+    _run(
+        "tacit.parse constraint failure",
+        lambda: Order.parse(
+            ibis.memtable({"amount": [-1.0], "status": ["pending"]})
+        ),
+    )
+
+    _run(
+        "pandera eager missing column",
+        lambda: schema.validate(ibis.memtable({"amount": [1.0]})),
+    )
+
+    _run(
+        "pandera eager extra column",
+        lambda: schema.validate(
+            ibis.memtable(
+                {"amount": [1.0], "status": ["pending"], "extra": [1]}
+            )
+        ),
+    )
+
+    _run(
+        "pandera eager wrong dtype",
+        lambda: schema.validate(
+            ibis.memtable({"amount": ["bad"], "status": ["pending"]})
+        ),
+    )
+
+    _run(
+        "pandera eager check failure",
+        lambda: schema.validate(
+            ibis.memtable({"amount": [-1.0], "status": ["pending"]})
+        ),
+    )
+
+    _run(
+        "pandera lazy aggregated errors",
+        lambda: schema.validate(
+            ibis.memtable({"amount": [-1.0, 101.0], "status": ["bad", None]}),
+            lazy=True,
+        ),
+    )
+
+    _run(
+        "pandera custom check execution error",
+        lambda: pa.DataFrameSchema(
+            {
+                "a": pa.Column(
+                    int,
+                    checks=[pa.Check(lambda _: 1 / 0, error="boom")],
+                )
+            }
+        ).validate(ibis.memtable({"a": [1, 2, 3]})),
+    )
+
+    _run(
+        "contract(validate=True) input coercion failure",
+        lambda: validated_identity(
+            ibis.memtable({"amount": ["bad"], "status": ["pending"]})
+        ),
+    )
+
+    _run(
+        "contract(validate=True) input check failure",
+        lambda: validated_identity(
+            ibis.memtable({"amount": [-1.0], "status": ["pending"]})
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,30 @@
 
 ::: tacit.contract
 
+## tacit.errors.ValidationError
+
+::: tacit.errors.ValidationError
+
+## tacit.errors.StructuralError
+
+::: tacit.errors.StructuralError
+
+## tacit.errors.CoercionError
+
+::: tacit.errors.CoercionError
+
+## tacit.errors.ConstraintError
+
+::: tacit.errors.ConstraintError
+
+## tacit.errors.CheckExecutionError
+
+::: tacit.errors.CheckExecutionError
+
+## tacit.errors.ValidationPhase
+
+::: tacit.errors.ValidationPhase
+
 ## Check
 
 ::: tacit.Check

--- a/docs/concepts/contracts.md
+++ b/docs/concepts/contracts.md
@@ -118,3 +118,29 @@ break the output schema's structural checks (or constraint checks, with
 `validate=True`).
 
 The contract is a boundary check, not a line-by-line audit.
+
+## Error handling
+
+Contract failures use the same exception family as `cast()` and `parse()`, but
+with contract-specific boundary context attached:
+
+```python
+from tacit.errors import ValidationError, ValidationPhase
+
+try:
+    result = transform(df)
+except ValidationError as exc:
+    if exc.phase is ValidationPhase.CONTRACT_INPUT:
+        ...
+    elif exc.phase is ValidationPhase.CONTRACT_OUTPUT:
+        ...
+```
+
+The concrete subclasses are:
+
+- `StructuralError`
+- `CoercionError`
+- `ConstraintError`
+- `CheckExecutionError`
+
+Import them from `tacit.errors`.

--- a/docs/concepts/dataframes.md
+++ b/docs/concepts/dataframes.md
@@ -92,3 +92,29 @@ You can only get one through:
 This means a `DataFrame[S]` always represents data that has been verified
 against schema `S` — either fully via `parse()`, or structurally via `cast()`
 with the user vouching for the rest.
+
+## Validation errors
+
+`cast()` and `parse()` raise tacit's own exception types from `tacit.errors`.
+This gives you a stable way to handle validation failures without depending on
+backend-specific exception classes:
+
+```python
+from tacit.errors import CoercionError, ConstraintError, StructuralError
+
+try:
+    orders = Order.parse(raw)
+except StructuralError:
+    # Missing columns, extra columns, wrong dtypes in structural validation
+    ...
+except CoercionError:
+    # Data couldn't be cast into the schema's target types
+    ...
+except ConstraintError:
+    # Data has the right shape but violates checks/nullability
+    ...
+```
+
+All of these inherit from `ValidationError`. Each exception exposes the schema
+being enforced and the validation phase, and preserves the original pandera or
+backend exception when there is one.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ build-backend = "uv_build"
 dev = [
     "ibis-framework[duckdb]>=9.0.0",
     "ipython>=9.7.0",
+    "polars>=1.0.0",
     "pyright>=1.1.400",
     "pytest>=8.4.2",
     "ruff>=0.11.0",

--- a/src/tacit/contract.py
+++ b/src/tacit/contract.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import functools
 import inspect
-from typing import Any, Callable, ParamSpec, TypeVar, get_type_hints, overload
+from typing import Any, Callable, ParamSpec, TypeVar, get_args, get_origin, get_type_hints, overload
 
 import ibis.expr.types as ir
 
+from .errors import ValidationError, ValidationPhase, recontextualize_validation_error
 from .schema import DataFrame, Schema
 
 P = ParamSpec("P")
@@ -15,9 +16,9 @@ S = TypeVar("S", bound=Schema)
 
 def _get_schema_type(annotation: Any) -> type[Schema] | None:
     """Extract the Schema type S from a DataFrame[S] annotation, or None."""
-    if getattr(annotation, "__origin__", None) is not DataFrame:
+    if get_origin(annotation) is not DataFrame:
         return None
-    args = getattr(annotation, "__args__", ())
+    args = get_args(annotation)
     if args and isinstance(args[0], type) and issubclass(args[0], Schema):
         return args[0]
     return None
@@ -41,8 +42,8 @@ def _enforce(
 
     Raises:
         TypeError: If value is not an ibis Table expression.
-        ValueError/TypeError: Re-raised from cast()/parse() with context about
-            which parameter and schema failed.
+        tacit.errors.ValidationError: Re-raised from cast()/parse() with
+            contract-specific boundary context.
     """
     if not isinstance(value, ir.Table):
         raise TypeError(
@@ -54,10 +55,18 @@ def _enforce(
         if validate:
             return schema_type.parse(value)
         return schema_type.cast(value)
-    except (TypeError, ValueError) as exc:
-        raise type(exc)(
-            f"Contract violation on {label} [{schema_type.__name__}]: {exc}"
-        ) from exc
+    except ValidationError as exc:
+        phase = (
+            ValidationPhase.CONTRACT_OUTPUT
+            if label == "return value"
+            else ValidationPhase.CONTRACT_INPUT
+        )
+        contract_exc = recontextualize_validation_error(
+            exc,
+            phase=phase,
+            boundary_label=label,
+        )
+        raise contract_exc from exc
 
 
 @overload

--- a/src/tacit/contract.py
+++ b/src/tacit/contract.py
@@ -2,7 +2,16 @@ from __future__ import annotations
 
 import functools
 import inspect
-from typing import Any, Callable, ParamSpec, TypeVar, get_args, get_origin, get_type_hints, overload
+from typing import (
+    Any,
+    Callable,
+    ParamSpec,
+    TypeVar,
+    get_args,
+    get_origin,
+    get_type_hints,
+    overload,
+)
 
 import ibis.expr.types as ir
 

--- a/src/tacit/errors.py
+++ b/src/tacit/errors.py
@@ -270,6 +270,11 @@ def looks_like_coercion_failure(exc: BaseException) -> bool:
         "Conversion" in name
         or "Conversion Error" in text
         or "Could not convert" in text
+        or (
+            "InvalidOperationError" in name
+            and "conversion from `" in text
+            and "failed in column" in text
+        )
     )
 
 

--- a/src/tacit/errors.py
+++ b/src/tacit/errors.py
@@ -230,6 +230,20 @@ def validation_error_from_pandera(
     )
 
 
+def validation_error_from_execution(
+    *,
+    schema: type[Schema],
+    phase: ValidationPhase,
+    original: BaseException,
+) -> ValidationError:
+    return ValidationError(
+        schema=schema,
+        phase=phase,
+        detail=_ensure_period(_summarize_original(original)),
+        original=original,
+    )
+
+
 def recontextualize_validation_error(
     exc: ValidationError,
     *,
@@ -246,6 +260,16 @@ def recontextualize_validation_error(
         failure_cases=exc.failure_cases,
         column=exc.column,
         original=exc.original,
+    )
+
+
+def looks_like_coercion_failure(exc: BaseException) -> bool:
+    name = type(exc).__name__
+    text = str(exc)
+    return (
+        "Conversion" in name
+        or "Conversion Error" in text
+        or "Could not convert" in text
     )
 
 

--- a/src/tacit/errors.py
+++ b/src/tacit/errors.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+import pandera.errors as pe
+
+if TYPE_CHECKING:
+    from .schema import Schema
+
+
+class ValidationPhase(Enum):
+    CAST = "cast"
+    PARSE = "parse"
+    CONTRACT_INPUT = "contract_input"
+    CONTRACT_OUTPUT = "contract_output"
+
+
+class ValidationError(Exception):
+    """Base class for tacit validation failures."""
+
+    _summary = "Validation"
+
+    def __init__(
+        self,
+        *,
+        schema: type[Schema],
+        phase: ValidationPhase,
+        detail: str | None = None,
+        boundary_label: str | None = None,
+        reason_code: str | None = None,
+        check: object | None = None,
+        failure_cases: object | None = None,
+        column: str | None = None,
+        original: BaseException | None = None,
+    ) -> None:
+        self.schema = schema
+        self.phase = phase
+        self.detail = detail
+        self.boundary_label = boundary_label
+        self.reason_code = reason_code
+        self.check = check
+        self.failure_cases = failure_cases
+        self.column = column
+        self.original = original
+        super().__init__(self._build_message())
+
+    def _build_message(self) -> str:
+        message = f"{self._summary} failed for schema {self.schema.__name__} {self._phase_phrase()}."
+        if self.detail:
+            return f"{message[:-1]}: {self.detail}"
+        return message
+
+    def _phase_phrase(self) -> str:
+        if self.phase is ValidationPhase.CAST:
+            return "during cast"
+        if self.phase is ValidationPhase.PARSE:
+            return "during parse"
+        if self.phase is ValidationPhase.CONTRACT_INPUT:
+            return f"on {self.boundary_label or 'contract input'}"
+        return f"on {self.boundary_label or 'return value'}"
+
+
+class StructuralError(ValidationError):
+    _summary = "Structural validation"
+
+
+class CoercionError(ValidationError):
+    _summary = "Coercion"
+
+
+class ConstraintError(ValidationError):
+    _summary = "Constraint validation"
+
+
+class CheckExecutionError(ValidationError):
+    _summary = "Check execution"
+
+
+_STRUCTURAL_REASON_CODES = {
+    pe.SchemaErrorReason.COLUMN_NOT_IN_DATAFRAME,
+    pe.SchemaErrorReason.COLUMN_NOT_IN_SCHEMA,
+    pe.SchemaErrorReason.WRONG_DATATYPE,
+}
+_CHECK_EXECUTION_REASON_CODES = {pe.SchemaErrorReason.CHECK_ERROR}
+
+
+def structural_error_for_columns(
+    *,
+    schema: type[Schema],
+    phase: ValidationPhase,
+    missing: list[str],
+    extra: list[str],
+) -> StructuralError:
+    parts = []
+    if missing:
+        parts.append(f"missing columns {missing}")
+    if extra:
+        parts.append(f"extra columns {extra}")
+    detail = "; ".join(parts) + "."
+    return StructuralError(schema=schema, phase=phase, detail=detail)
+
+
+def structural_error_for_type_mismatches(
+    *,
+    schema: type[Schema],
+    phase: ValidationPhase,
+    mismatches: list[tuple[str, Any, Any]],
+) -> StructuralError:
+    if len(mismatches) == 1:
+        column, expected, actual = mismatches[0]
+        detail = f"column '{column}' expected {expected}, got {actual}."
+        return StructuralError(
+            schema=schema,
+            phase=phase,
+            detail=detail,
+            column=column,
+        )
+
+    pieces = [
+        f"{column} expected {expected}, got {actual}"
+        for column, expected, actual in mismatches
+    ]
+    detail = "column type mismatches: " + "; ".join(pieces) + "."
+    return StructuralError(schema=schema, phase=phase, detail=detail)
+
+
+def coercion_error_for_cast_failure(
+    *,
+    schema: type[Schema],
+    phase: ValidationPhase,
+    cast_map: dict[str, Any],
+    original: BaseException,
+) -> CoercionError:
+    columns = list(cast_map)
+    if len(columns) == 1:
+        column = columns[0]
+        detail = (
+            f"failed to cast column '{column}' to {cast_map[column]}. "
+            f"{_summarize_original(original)}"
+        )
+        return CoercionError(
+            schema=schema,
+            phase=phase,
+            detail=detail,
+            column=column,
+            original=original,
+        )
+
+    detail = (
+        f"failed to cast columns {columns} to target schema types. "
+        f"{_summarize_original(original)}"
+    )
+    return CoercionError(
+        schema=schema,
+        phase=phase,
+        detail=detail,
+        original=original,
+    )
+
+
+def validation_error_from_pandera(
+    *,
+    schema: type[Schema],
+    phase: ValidationPhase,
+    original: BaseException,
+) -> ValidationError:
+    if isinstance(original, pe.SchemaErrors):
+        detail = f"multiple validation errors detected ({len(original.schema_errors)} errors)."
+        return ConstraintError(
+            schema=schema,
+            phase=phase,
+            detail=detail,
+            failure_cases=original.failure_cases,
+            original=original,
+        )
+
+    if not isinstance(original, pe.SchemaError):
+        return ValidationError(
+            schema=schema,
+            phase=phase,
+            detail=_summarize_original(original),
+            original=original,
+        )
+
+    reason_code = original.reason_code
+    reason_value = reason_code.value if reason_code is not None else None
+    column = _extract_column(original)
+    check = original.check
+    failure_cases = original.failure_cases
+
+    if reason_code in _CHECK_EXECUTION_REASON_CODES:
+        detail = f"check {_format_check(check)} raised {_summarize_original(original)}"
+        return CheckExecutionError(
+            schema=schema,
+            phase=phase,
+            detail=detail,
+            boundary_label=None,
+            reason_code=reason_value,
+            check=check,
+            failure_cases=failure_cases,
+            column=column,
+            original=original,
+        )
+
+    if reason_code in _STRUCTURAL_REASON_CODES:
+        detail = _structural_detail_from_pandera(original, column)
+        return StructuralError(
+            schema=schema,
+            phase=phase,
+            detail=detail,
+            reason_code=reason_value,
+            check=check,
+            failure_cases=failure_cases,
+            column=column,
+            original=original,
+        )
+
+    detail = _constraint_detail_from_pandera(original, column)
+    return ConstraintError(
+        schema=schema,
+        phase=phase,
+        detail=detail,
+        reason_code=reason_value,
+        check=check,
+        failure_cases=failure_cases,
+        column=column,
+        original=original,
+    )
+
+
+def recontextualize_validation_error(
+    exc: ValidationError,
+    *,
+    phase: ValidationPhase,
+    boundary_label: str,
+) -> ValidationError:
+    return type(exc)(
+        schema=exc.schema,
+        phase=phase,
+        detail=exc.detail,
+        boundary_label=boundary_label,
+        reason_code=exc.reason_code,
+        check=exc.check,
+        failure_cases=exc.failure_cases,
+        column=exc.column,
+        original=exc.original,
+    )
+
+
+def _extract_column(exc: pe.SchemaError) -> str | None:
+    if exc.column_name:
+        return str(exc.column_name)
+    schema_name = getattr(exc.schema, "name", None)
+    if schema_name:
+        return str(schema_name)
+    return None
+
+
+def _format_check(check: object | None) -> str:
+    if check is None:
+        return "validation check"
+    name = getattr(check, "error", None) or getattr(check, "name", None)
+    if name:
+        return str(name)
+    return str(check)
+
+
+def _constraint_detail_from_pandera(exc: pe.SchemaError, column: str | None) -> str:
+    if exc.reason_code is pe.SchemaErrorReason.SERIES_CONTAINS_NULLS and column:
+        return f"column '{column}' contains null values."
+    if column and exc.check is not None:
+        return f"column '{column}' failed check {_format_check(exc.check)}."
+    return _ensure_period(_summarize_original(exc))
+
+
+def _structural_detail_from_pandera(exc: pe.SchemaError, column: str | None) -> str:
+    if exc.reason_code is pe.SchemaErrorReason.COLUMN_NOT_IN_DATAFRAME:
+        missing = exc.failure_cases if isinstance(exc.failure_cases, str) else column
+        if missing:
+            return f"missing column '{missing}'."
+    if exc.reason_code is pe.SchemaErrorReason.COLUMN_NOT_IN_SCHEMA:
+        extra = exc.failure_cases if isinstance(exc.failure_cases, str) else column
+        if extra:
+            return f"unexpected column '{extra}'."
+    if exc.reason_code is pe.SchemaErrorReason.WRONG_DATATYPE:
+        actual = exc.failure_cases if isinstance(exc.failure_cases, str) else "unknown"
+        expected = _extract_expected_dtype(exc.check)
+        if column and expected:
+            return f"column '{column}' expected {expected}, got {actual}."
+    return _ensure_period(_summarize_original(exc))
+
+
+def _extract_expected_dtype(check: object | None) -> str | None:
+    if not isinstance(check, str):
+        return None
+    match = re.search(r"dtype\\('([^']+)'\\)", check)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _summarize_original(exc: BaseException) -> str:
+    text = str(exc).strip()
+    if not text:
+        return exc.__class__.__name__
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    return _ensure_period(first_line)
+
+
+def _ensure_period(text: str) -> str:
+    return text if text.endswith(".") else f"{text}."

--- a/src/tacit/schema.py
+++ b/src/tacit/schema.py
@@ -4,9 +4,17 @@ from typing import Annotated, ClassVar, Self, get_args, get_origin, get_type_hin
 
 import ibis
 import ibis.expr.types as ir
+import pandera.errors as pe
 import pandera.ibis as pa
 
 from .constraints import Nullable
+from .errors import (
+    ValidationPhase,
+    coercion_error_for_cast_failure,
+    structural_error_for_columns,
+    structural_error_for_type_mismatches,
+    validation_error_from_pandera,
+)
 
 
 class DataFrame[S: "Schema"](ir.Table):
@@ -90,17 +98,25 @@ class Schema:
         return pa.DataFrameSchema(columns, strict=True)
 
     @classmethod
-    def _check_columns(cls, target: ibis.Schema, actual: ibis.Schema) -> None:
+    def _check_columns(
+        cls,
+        target: ibis.Schema,
+        actual: ibis.Schema,
+        *,
+        phase: ValidationPhase,
+    ) -> None:
         target_names = set(target.names)  # type: ignore[reportArgumentType]  # ibis has no py.typed
         actual_names = set(actual.names)  # type: ignore[reportArgumentType]  # ibis has no py.typed
 
         missing = sorted(target_names - actual_names)
-        if missing:
-            raise ValueError(f"Missing columns: {missing}")
-
         extra = sorted(actual_names - target_names)
-        if extra:
-            raise ValueError(f"Extra columns: {extra}")
+        if missing or extra:
+            raise structural_error_for_columns(
+                schema=cls,
+                phase=phase,
+                missing=missing,
+                extra=extra,
+            )
 
     @classmethod
     def parse(cls, table: ir.Table) -> DataFrame[Self]:
@@ -110,12 +126,12 @@ class Schema:
         you're ingesting untrusted data.
 
         Raises:
-            ValueError: Missing or extra columns.
-            pandera.errors.SchemaError: Data fails validation checks.
+            tacit.errors.ValidationError: Data fails structural, coercion, or
+                validation checks.
         """
         target = cls._ibis_schema()
         actual = table.schema()
-        cls._check_columns(target, actual)
+        cls._check_columns(target, actual, phase=ValidationPhase.PARSE)
 
         # Pandera's ibis backend doesn't support coercion — handle it ourselves
         cast_map = {
@@ -124,9 +140,36 @@ class Schema:
             if actual[col] != target_type
         }
         if cast_map:
-            table = table.cast(cast_map)
+            try:
+                table = table.cast(cast_map)
+            except Exception as exc:
+                coercion_error = coercion_error_for_cast_failure(
+                    schema=cls,
+                    phase=ValidationPhase.PARSE,
+                    cast_map=cast_map,
+                    original=exc,
+                )
+                raise coercion_error from exc
 
-        validated = cls._pandera_schema().validate(table)
+        try:
+            validated = cls._pandera_schema().validate(table)
+        except (pe.SchemaError, pe.SchemaErrors) as exc:
+            validation_error = validation_error_from_pandera(
+                schema=cls,
+                phase=ValidationPhase.PARSE,
+                original=exc,
+            )
+            raise validation_error from exc
+        except Exception as exc:
+            if cast_map:
+                coercion_error = coercion_error_for_cast_failure(
+                    schema=cls,
+                    phase=ValidationPhase.PARSE,
+                    cast_map=cast_map,
+                    original=exc,
+                )
+                raise coercion_error from exc
+            raise
         return DataFrame._from_table(validated, cls)
 
     @classmethod
@@ -137,22 +180,34 @@ class Schema:
         boundaries where you trust the data but want type safety.
 
         Raises:
-            ValueError: Missing or extra columns (strict mode).
-            TypeError: Column type mismatch.
+            tacit.errors.StructuralError: Missing, extra, or wrong-type columns.
         """
         target = cls._ibis_schema()
         actual = table.schema()
-        cls._check_columns(target, actual)
+        target_names = set(target.names)  # type: ignore[reportArgumentType]
+        actual_names = set(actual.names)  # type: ignore[reportArgumentType]
+        missing = sorted(target_names - actual_names)
+        extra = sorted(actual_names - target_names)
+        if missing or extra:
+            raise structural_error_for_columns(
+                schema=cls,
+                phase=ValidationPhase.CAST,
+                missing=missing,
+                extra=extra,
+            )
 
-        type_errors = []
+        type_errors: list[tuple[str, object, object]] = []
         for col_name, expected_type in target.items():
             actual_type = actual[col_name]
             if actual_type != expected_type:
                 type_errors.append(
-                    f"  {col_name}: expected {expected_type}, got {actual_type}"
+                    (col_name, expected_type, actual_type)
                 )
         if type_errors:
-            detail = "\n".join(type_errors)
-            raise TypeError(f"Column type mismatches:\n{detail}")
+            raise structural_error_for_type_mismatches(
+                schema=cls,
+                phase=ValidationPhase.CAST,
+                mismatches=type_errors,
+            )
 
         return DataFrame._from_table(table, cls)

--- a/src/tacit/schema.py
+++ b/src/tacit/schema.py
@@ -11,8 +11,10 @@ from .constraints import Nullable
 from .errors import (
     ValidationPhase,
     coercion_error_for_cast_failure,
+    looks_like_coercion_failure,
     structural_error_for_columns,
     structural_error_for_type_mismatches,
+    validation_error_from_execution,
     validation_error_from_pandera,
 )
 
@@ -161,7 +163,7 @@ class Schema:
             )
             raise validation_error from exc
         except Exception as exc:
-            if cast_map:
+            if cast_map and looks_like_coercion_failure(exc):
                 coercion_error = coercion_error_for_cast_failure(
                     schema=cls,
                     phase=ValidationPhase.PARSE,
@@ -169,7 +171,12 @@ class Schema:
                     original=exc,
                 )
                 raise coercion_error from exc
-            raise
+            validation_error = validation_error_from_execution(
+                schema=cls,
+                phase=ValidationPhase.PARSE,
+                original=exc,
+            )
+            raise validation_error from exc
         return DataFrame._from_table(validated, cls)
 
     @classmethod

--- a/src/tacit/schema.py
+++ b/src/tacit/schema.py
@@ -200,9 +200,7 @@ class Schema:
         for col_name, expected_type in target.items():
             actual_type = actual[col_name]
             if actual_type != expected_type:
-                type_errors.append(
-                    (col_name, expected_type, actual_type)
-                )
+                type_errors.append((col_name, expected_type, actual_type))
         if type_errors:
             raise structural_error_for_type_mismatches(
                 schema=cls,

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -2,6 +2,7 @@ import ibis
 import pytest
 
 from tacit import DataFrame, Schema, contract
+from tacit.errors import ConstraintError, StructuralError
 
 
 class Iris(Schema):
@@ -149,7 +150,7 @@ def test_contract_input_missing_columns():
         return df
 
     table = ibis.memtable({"species": ["setosa"]})
-    with pytest.raises(ValueError, match=r"parameter 'df'.*Iris"):
+    with pytest.raises(StructuralError, match=r"Iris.*parameter 'df'"):
         fn(table)
 
 
@@ -165,7 +166,7 @@ def test_contract_input_extra_columns():
             "EXTRA": [1],
         }
     )
-    with pytest.raises(ValueError, match=r"parameter 'df'.*Iris"):
+    with pytest.raises(StructuralError, match=r"Iris.*parameter 'df'"):
         fn(table)
 
 
@@ -175,7 +176,7 @@ def test_contract_input_wrong_type():
         return df
 
     table = ibis.memtable({"sepal_length": ["bad"], "species": ["setosa"]})
-    with pytest.raises(TypeError, match=r"parameter 'df'.*Iris"):
+    with pytest.raises(StructuralError, match=r"Iris.*parameter 'df'"):
         fn(table)
 
 
@@ -184,7 +185,7 @@ def test_contract_output_schema_mismatch():
     def fn(df: DataFrame[Iris]) -> DataFrame[IrisFeatures]:
         return df
 
-    with pytest.raises((ValueError, TypeError), match=r"return value.*IrisFeatures"):
+    with pytest.raises(StructuralError, match=r"IrisFeatures.*return value"):
         fn(_iris_table())
 
 
@@ -256,5 +257,19 @@ def test_contract_returns_param_output_schema_mismatch():
     def fn(df: DataFrame[Iris]):
         return df
 
-    with pytest.raises((ValueError, TypeError), match=r"return value.*IrisFeatures"):
+    with pytest.raises(StructuralError, match=r"IrisFeatures.*return value"):
         fn(_iris_table())
+
+
+def test_contract_validate_propagates_constraint_error_with_contract_context():
+    class PositiveIris(Schema):
+        sepal_length: float
+        species: str
+
+    @contract(validate=True)
+    def fn(df: DataFrame[PositiveIris]) -> DataFrame[PositiveIris]:
+        return df
+
+    table = ibis.memtable({"sepal_length": [5.1], "species": [None]})
+    with pytest.raises(ConstraintError, match=r"parameter 'df'"):
+        fn(table)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -81,6 +81,32 @@ def test_parse_unrelated_execution_failure_after_cast_is_not_coercion_error():
     assert "unbound tables" in str(exc).lower()
 
 
+def test_parse_polars_coercion_failure_raises_coercion_error_when_backend_available():
+    import polars as pl
+
+    con = ibis.polars.connect()
+    table = con.create_table(
+        "orders_tmp",
+        pl.DataFrame(
+            {
+                "amount": ["bad", "-1", "10"],
+                "status": ["pending", None, "pending"],
+            }
+        ),
+        overwrite=True,
+    )
+
+    with pytest.raises(CoercionError) as exc_info:
+        Order.parse(table)
+
+    exc = exc_info.value
+    assert exc.phase is ValidationPhase.PARSE
+    assert exc.schema is Order
+    assert exc.original is not None
+    assert exc_info.value.__cause__ is exc.original
+    assert "failed to cast column 'amount' to float64" in str(exc)
+
+
 def test_parse_constraint_failure_raises_constraint_error():
     with pytest.raises(ConstraintError) as exc_info:
         Order.parse(ibis.memtable({"amount": [-1.0], "status": ["pending"]}))

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -64,6 +64,23 @@ def test_parse_coercion_failure_raises_coercion_error():
     assert "failed to cast column 'amount' to float64" in str(exc)
 
 
+def test_parse_unrelated_execution_failure_after_cast_is_not_coercion_error():
+    class SingleFloat(Schema):
+        a: float
+
+    with pytest.raises(ValidationError) as exc_info:
+        SingleFloat.parse(ibis.table({"a": "int64"}, name="nonexistent"))
+
+    exc = exc_info.value
+    assert type(exc) is ValidationError
+    assert not isinstance(exc, CoercionError)
+    assert exc.phase is ValidationPhase.PARSE
+    assert exc.schema is SingleFloat
+    assert exc.original is not None
+    assert exc_info.value.__cause__ is exc.original
+    assert "unbound tables" in str(exc).lower()
+
+
 def test_parse_constraint_failure_raises_constraint_error():
     with pytest.raises(ConstraintError) as exc_info:
         Order.parse(ibis.memtable({"amount": [-1.0], "status": ["pending"]}))

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,145 @@
+from typing import Annotated
+
+import ibis
+import pandera.ibis as pa
+import pytest
+
+from tacit import Check, DataFrame, Schema, contract
+from tacit.errors import (
+    CheckExecutionError,
+    CoercionError,
+    ConstraintError,
+    StructuralError,
+    ValidationError,
+    ValidationPhase,
+)
+
+
+class Order(Schema):
+    amount: Annotated[float, Check.ge(0)]
+    status: str
+
+
+class OrderOut(Order):
+    total: float
+
+
+class ExplodingCheck(Schema):
+    value: Annotated[int, pa.Check(lambda _: 1 / 0, error="boom")]
+
+
+def test_cast_missing_columns_raises_structural_error():
+    with pytest.raises(StructuralError) as exc_info:
+        Order.cast(ibis.memtable({"amount": [1.0]}))
+
+    exc = exc_info.value
+    assert exc.phase is ValidationPhase.CAST
+    assert exc.schema is Order
+    assert exc.original is None
+    assert exc.boundary_label is None
+    assert "missing columns ['status']" in str(exc)
+
+
+def test_cast_multiple_type_mismatches_reported_in_message():
+    with pytest.raises(StructuralError) as exc_info:
+        Order.cast(ibis.memtable({"amount": ["bad"], "status": [1]}))
+
+    exc = exc_info.value
+    assert exc.phase is ValidationPhase.CAST
+    assert exc.column is None
+    assert "amount expected float64, got string" in str(exc)
+    assert "status expected string, got int64" in str(exc)
+
+
+def test_parse_coercion_failure_raises_coercion_error():
+    with pytest.raises(CoercionError) as exc_info:
+        Order.parse(ibis.memtable({"amount": ["bad"], "status": ["pending"]}))
+
+    exc = exc_info.value
+    assert exc.phase is ValidationPhase.PARSE
+    assert exc.schema is Order
+    assert exc.column == "amount"
+    assert exc.original is not None
+    assert exc_info.value.__cause__ is exc.original
+    assert "failed to cast column 'amount' to float64" in str(exc)
+
+
+def test_parse_constraint_failure_raises_constraint_error():
+    with pytest.raises(ConstraintError) as exc_info:
+        Order.parse(ibis.memtable({"amount": [-1.0], "status": ["pending"]}))
+
+    exc = exc_info.value
+    assert exc.phase is ValidationPhase.PARSE
+    assert exc.schema is Order
+    assert exc.reason_code == "dataframe_check"
+    assert exc.column == "amount"
+    assert exc.check is not None
+    assert exc.original is not None
+    assert exc_info.value.__cause__ is exc.original
+    assert "column 'amount' failed check" in str(exc)
+
+
+def test_parse_check_execution_failure_raises_check_execution_error():
+    with pytest.raises(CheckExecutionError) as exc_info:
+        ExplodingCheck.parse(ibis.memtable({"value": [1, 2, 3]}))
+
+    exc = exc_info.value
+    assert exc.phase is ValidationPhase.PARSE
+    assert exc.schema is ExplodingCheck
+    assert exc.reason_code == "check_error"
+    assert exc.original is not None
+    assert exc_info.value.__cause__ is exc.original
+    assert "check boom raised ZeroDivisionError" in str(exc)
+
+
+def test_contract_recontextualizes_structural_input_error():
+    @contract
+    def fn(df: DataFrame[Order]) -> DataFrame[Order]:
+        return df
+
+    with pytest.raises(StructuralError) as exc_info:
+        fn(ibis.memtable({"amount": [1.0]}))
+
+    exc = exc_info.value
+    assert exc.phase is ValidationPhase.CONTRACT_INPUT
+    assert exc.boundary_label == "parameter 'df'"
+    assert exc.original is None
+    assert isinstance(exc_info.value.__cause__, StructuralError)
+    assert "on parameter 'df'" in str(exc)
+
+
+def test_contract_recontextualizes_validated_input_error_with_root_original():
+    @contract(validate=True)
+    def fn(df: DataFrame[Order]) -> DataFrame[Order]:
+        return df
+
+    with pytest.raises(ConstraintError) as exc_info:
+        fn(ibis.memtable({"amount": [-1.0], "status": ["pending"]}))
+
+    exc = exc_info.value
+    assert exc.phase is ValidationPhase.CONTRACT_INPUT
+    assert exc.boundary_label == "parameter 'df'"
+    assert exc.original is not None
+    assert isinstance(exc_info.value.__cause__, ConstraintError)
+    assert exc_info.value.__cause__ is not exc.original
+    assert "on parameter 'df'" in str(exc)
+
+
+def test_contract_recontextualizes_return_error():
+    @contract(returns=OrderOut, validate=True)
+    def fn(df: DataFrame[Order]):
+        return df
+
+    with pytest.raises(StructuralError) as exc_info:
+        fn(ibis.memtable({"amount": [1.0], "status": ["pending"]}))
+
+    exc = exc_info.value
+    assert exc.phase is ValidationPhase.CONTRACT_OUTPUT
+    assert exc.boundary_label == "return value"
+    assert isinstance(exc_info.value.__cause__, StructuralError)
+    assert "on return value" in str(exc)
+
+
+def test_all_validation_errors_share_common_base_class():
+    with pytest.raises(ValidationError):
+        Order.cast(ibis.memtable({"amount": [1.0]}))

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -4,7 +4,12 @@ import ibis
 import pytest
 
 from tacit import Check, DataFrame, Nullable, Schema
-from tacit.errors import CheckExecutionError, CoercionError, ConstraintError, StructuralError
+from tacit.errors import (
+    CheckExecutionError,
+    CoercionError,
+    ConstraintError,
+    StructuralError,
+)
 
 
 class Iris(Schema):
@@ -270,7 +275,9 @@ def test_parse_maps_check_execution_failures():
         value: Annotated[int, Check(lambda _: 1 / 0, error="boom")]
 
     table = ibis.memtable({"value": [1, 2, 3]})
-    with pytest.raises(CheckExecutionError, match="check boom raised ZeroDivisionError"):
+    with pytest.raises(
+        CheckExecutionError, match="check boom raised ZeroDivisionError"
+    ):
         Exploding.parse(table)
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,10 +1,10 @@
 from typing import Annotated
 
 import ibis
-import pandera.errors
 import pytest
 
 from tacit import Check, DataFrame, Nullable, Schema
+from tacit.errors import CheckExecutionError, CoercionError, ConstraintError, StructuralError
 
 
 class Iris(Schema):
@@ -44,13 +44,13 @@ def test_cast_does_not_execute_query():
 
 def test_cast_rejects_missing_columns():
     table = ibis.memtable({"species": ["setosa"]})
-    with pytest.raises(ValueError, match="sepal_length"):
+    with pytest.raises(StructuralError, match="sepal_length"):
         Iris.cast(table)
 
 
 def test_cast_rejects_multiple_missing_columns():
     table = ibis.memtable({"unrelated": [1]})
-    with pytest.raises(ValueError, match="Missing columns"):
+    with pytest.raises(StructuralError, match="missing columns"):
         Iris.cast(table)
 
 
@@ -62,7 +62,7 @@ def test_cast_rejects_extra_columns():
             "EXTRA": [999],
         }
     )
-    with pytest.raises(ValueError, match="EXTRA"):
+    with pytest.raises(StructuralError, match="EXTRA"):
         Iris.cast(table)
 
 
@@ -73,7 +73,7 @@ def test_cast_rejects_wrong_type():
             "species": ["setosa"],
         }
     )
-    with pytest.raises(TypeError, match=r"sepal_length.*float64.*string"):
+    with pytest.raises(StructuralError, match=r"sepal_length.*float64.*string"):
         Iris.cast(table)
 
 
@@ -85,7 +85,7 @@ def test_cast_reports_all_type_mismatches():
             "species": [123],
         }
     )
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(StructuralError) as exc_info:
         Iris.cast(table)
     msg = str(exc_info.value)
     assert "sepal_length" in msg
@@ -95,7 +95,7 @@ def test_cast_reports_all_type_mismatches():
 def test_cast_checks_missing_before_types():
     """Missing columns are caught before type checking (can't check types on absent columns)."""
     table = ibis.memtable({"species": [123]})
-    with pytest.raises(ValueError, match="Missing"):
+    with pytest.raises(StructuralError, match="missing columns"):
         Iris.cast(table)
 
 
@@ -109,7 +109,7 @@ def test_cast_checks_extra_before_types():
             "extra": [2],
         }
     )
-    with pytest.raises(ValueError, match="Extra"):
+    with pytest.raises(StructuralError, match="extra columns"):
         Iris.cast(table)
 
 
@@ -143,7 +143,7 @@ def test_parse_coerces_compatible_types():
 
 def test_parse_rejects_missing_columns():
     table = ibis.memtable({"species": ["setosa"]})
-    with pytest.raises(ValueError, match="sepal_length"):
+    with pytest.raises(StructuralError, match="sepal_length"):
         Iris.parse(table)
 
 
@@ -155,7 +155,13 @@ def test_parse_rejects_extra_columns():
             "EXTRA": [999],
         }
     )
-    with pytest.raises(ValueError, match="EXTRA"):
+    with pytest.raises(StructuralError, match="EXTRA"):
+        Iris.parse(table)
+
+
+def test_parse_rejects_invalid_coercion():
+    table = ibis.memtable({"sepal_length": ["bad"], "species": ["setosa"]})
+    with pytest.raises(CoercionError, match="failed to cast column 'sepal_length'"):
         Iris.parse(table)
 
 
@@ -211,19 +217,19 @@ def test_parse_passes_when_constraints_satisfied():
 
 def test_parse_rejects_ge_violation():
     table = _order_table(amount=[-5.0, 10.0])
-    with pytest.raises(pandera.errors.SchemaError, match="amount"):
+    with pytest.raises(ConstraintError, match="amount"):
         Order.parse(table)
 
 
 def test_parse_rejects_isin_violation():
     table = _order_table(status=["pending", "INVALID"])
-    with pytest.raises(pandera.errors.SchemaError, match="status"):
+    with pytest.raises(ConstraintError, match="status"):
         Order.parse(table)
 
 
 def test_parse_rejects_multiple_checks_on_same_column():
     table = ibis.memtable({"score": [150.0]})
-    with pytest.raises(pandera.errors.SchemaError, match="score"):
+    with pytest.raises(ConstraintError, match="score"):
         BoundedScore.parse(table)
 
 
@@ -237,7 +243,7 @@ def test_parse_rejects_null_by_default():
     table = ibis.memtable(
         {"sepal_length": [5.1, None], "species": ["setosa", "setosa"]}
     )
-    with pytest.raises(pandera.errors.SchemaError, match="sepal_length"):
+    with pytest.raises(ConstraintError, match="sepal_length"):
         Iris.parse(table)
 
 
@@ -249,14 +255,23 @@ def test_parse_accepts_null_when_nullable():
 
 def test_parse_rejects_null_on_required_field():
     table = ibis.memtable({"required": ["a", None], "optional": ["x", "y"]})
-    with pytest.raises(pandera.errors.SchemaError, match="required"):
+    with pytest.raises(ConstraintError, match="required"):
         WithNullable.parse(table)
 
 
 def test_parse_enforces_inherited_constraints():
     table = ibis.memtable({"value": [-1.0], "name": ["test"]})
-    with pytest.raises(pandera.errors.SchemaError, match="value"):
+    with pytest.raises(ConstraintError, match="value"):
         ConstrainedChild.parse(table)
+
+
+def test_parse_maps_check_execution_failures():
+    class Exploding(Schema):
+        value: Annotated[int, Check(lambda _: 1 / 0, error="boom")]
+
+    table = ibis.memtable({"value": [1, 2, 3]})
+    with pytest.raises(CheckExecutionError, match="check boom raised ZeroDivisionError"):
+        Exploding.parse(table)
 
 
 def test_parse_passes_inherited_constraints_when_valid():

--- a/uv.lock
+++ b/uv.lock
@@ -862,6 +862,34 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.39.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/ab/f19e592fce9e000da49c96bf35e77cef67f9cb4b040bfa538a2764c0263e/polars-1.39.3.tar.gz", hash = "sha256:2e016c7f3e8d14fa777ef86fe0477cec6c67023a20ba4c94d6e8431eefe4a63c", size = 728987, upload-time = "2026-03-20T11:16:24.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/db/08f4ca10c5018813e7e0b59e4472302328b3d2ab1512f5a2157a814540e0/polars-1.39.3-py3-none-any.whl", hash = "sha256:c2b955ccc0a08a2bc9259785decf3d5c007b489b523bf2390cf21cec2bb82a56", size = 823985, upload-time = "2026-03-20T11:14:23.619Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.39.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/39/c8688696bc22b6c501e3b82ef3be10e543c07a785af5660f30997cd22dd2/polars_runtime_32-1.39.3.tar.gz", hash = "sha256:c728e4f469cafab501947585f36311b8fb222d3e934c6209e83791e0df20b29d", size = 2872335, upload-time = "2026-03-20T11:16:26.581Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/74/1b41205f7368c9375ab1dea91178eaa20435fe3eff036390a53a7660b416/polars_runtime_32-1.39.3-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:425c0b220b573fa097b4042edff73114cc6d23432a21dfd2dc41adf329d7d2e9", size = 45273243, upload-time = "2026-03-20T11:14:26.691Z" },
+    { url = "https://files.pythonhosted.org/packages/90/bf/297716b3095fe719be20fcf7af1d2b6ab069c38199bbace2469608a69b3a/polars_runtime_32-1.39.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ef5884711e3c617d7dc93519a7d038e242f5741cfe5fe9afd32d58845d86c562", size = 40842924, upload-time = "2026-03-20T11:14:31.154Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/e65236d9d0d9babfa0ecba593413c06530fca60a8feb8f66243aa5dba92e/polars_runtime_32-1.39.3-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06b47f535eb1f97a9a1e5b0053ef50db3a4276e241178e37bbb1a38b1fa53b14", size = 43220650, upload-time = "2026-03-20T11:14:35.458Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/15/fc3e43f3fdf3f20b7dfb5abe871ab6162cf8fb4aeabf4cfad822d5dc4c79/polars_runtime_32-1.39.3-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8bc9e13dc1d2e828331f2fe8ccbc9757554dc4933a8d3e85e906b988178f95ed", size = 46877498, upload-time = "2026-03-20T11:14:40.14Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/81/bd5f895919e32c6ab0a7786cd0c0ca961cb03152c47c3645808b54383f31/polars_runtime_32-1.39.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:363d49e3a3e638fc943e2b9887940300a7d06789930855a178a4727949259dc2", size = 43380176, upload-time = "2026-03-20T11:14:45.566Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/3e/c86433c3b5ec0315bdfc7640d0c15d41f1216c0103a0eab9a9b5147d6c4c/polars_runtime_32-1.39.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7c206bdcc7bc62ea038d6adea8e44b02f0e675e0191a54c810703b4895208ea4", size = 46485933, upload-time = "2026-03-20T11:14:51.155Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/200b310cf91f98e652eb6ea09fdb3a9718aa0293ebf113dce325797c8572/polars_runtime_32-1.39.3-cp310-abi3-win_amd64.whl", hash = "sha256:d66ca522517554a883446957539c40dc7b75eb0c2220357fb28bc8940d305339", size = 46995458, upload-time = "2026-03-20T11:14:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/da/76/2d48927e0aa2abbdde08cbf4a2536883b73277d47fbeca95e952de86df34/polars_runtime_32-1.39.3-cp310-abi3-win_arm64.whl", hash = "sha256:f49f51461de63f13e5dd4eb080421c8f23f856945f3f8bd5b2b1f59da52c2860", size = 41857648, upload-time = "2026-03-20T11:15:01.142Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -1257,6 +1285,7 @@ dependencies = [
 dev = [
     { name = "ibis-framework", extra = ["duckdb"] },
     { name = "ipython" },
+    { name = "polars" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "ruff" },
@@ -1278,6 +1307,7 @@ requires-dist = [
 dev = [
     { name = "ibis-framework", extras = ["duckdb"], specifier = ">=9.0.0" },
     { name = "ipython", specifier = ">=9.7.0" },
+    { name = "polars", specifier = ">=1.0.0" },
     { name = "pyright", specifier = ">=1.1.400" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "ruff", specifier = ">=0.11.0" },


### PR DESCRIPTION
## Summary
- add a dedicated `tacit.errors` validation exception family and `ValidationPhase`
- translate `Schema.cast()`, `Schema.parse()`, and `@contract` failures into the new tacit error surface
- add focused validation error tests plus docs and research for the design

## What changed
- added `ValidationError`, `StructuralError`, `CoercionError`, `ConstraintError`, and `CheckExecutionError` in `tacit.errors`
- classify tacit structural failures directly and map pandera reason codes into the new hierarchy
- preserve real pandera/backend exceptions as `original`/`__cause__` where applicable
- recontextualize the same error family for `@contract` input/output boundaries using `ValidationPhase`
- document the new API in the concepts and API docs

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pyright -p tests/typechecking`

## Context
- research spike: `dev/research/validation_error_handling.md`
- related issue: #35
